### PR TITLE
Add Superset config for file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # GobiernoDatos_SB_POC
 Prueba de concepto (POC) para plataforma analítica (Superintendencia de Bancos)
+
+## Superset Config
+
+Se incluye un archivo `superset_config.py` con flags básicos para habilitar la carga de archivos CSV/XLSX desde la interfaz y permitir conexiones a bases SQLite dentro del contenedor.
+
+Montar el archivo en la imagen de Superset añadiendo en `docker-compose.yml`:
+
+```yaml
+  volumes:
+    - ./staging:/app/superset_home
+    - ./superset_config.py:/app/pythonpath/superset_config.py
+```
+
+Con esto Superset podrá reconocer el directorio `staging/` como su `superset_home` y aceptará la carga manual de archivos.

--- a/superset_config.py
+++ b/superset_config.py
@@ -1,0 +1,8 @@
+FEATURE_FLAGS = {
+    "CSV_UPLOAD": True,
+}
+
+PREVENT_UNSAFE_DB_CONNECTIONS = False
+
+# Directory inside the container to store uploaded files
+UPLOAD_FOLDER = "/app/superset_home/uploads"


### PR DESCRIPTION
## Summary
- add a basic `superset_config.py` enabling CSV upload and SQLite usage
- document how to mount the config in docker-compose

## Testing
- `python -m py_compile superset_config.py`


------
https://chatgpt.com/codex/tasks/task_e_6848eb7a5c68832da5f7a485a6e72614